### PR TITLE
Properly escape mixed content in tags with <p> in EADs

### DIFF
--- a/plugin_info.txt
+++ b/plugin_info.txt
@@ -1,2 +1,2 @@
 AppConfig[:plugins] = ['princeton_ead_exporter']
-plugin_version:0.4.0
+plugin_version:0.5.0


### PR DESCRIPTION
Fixes an ASpace bug with ampersands in our notes. We should remove this
when it's fixed upstream.