### PR TITLE
Extending #serialize_note_content and #serialize_agent_notes in order to support the indexing of Agent primary names

### DIFF
--- a/plugin_info.txt
+++ b/plugin_info.txt
@@ -1,2 +1,2 @@
 AppConfig[:plugins] = ['princeton_ead_exporter']
-plugin_version:0.7.0
+plugin_version:0.8.0


### PR DESCRIPTION
This is necessary in order to advance https://github.com/pulibrary/pulfalight/issues/718